### PR TITLE
change FieldValue::String representation

### DIFF
--- a/crates/haste_core/src/bitreader.rs
+++ b/crates/haste_core/src/bitreader.rs
@@ -294,7 +294,7 @@ impl<'a> BitReader<'a> {
         num_chars
     }
 
-    // same as read_string, but grows the buffer and appends to to it instead of overwritting.
+    // same as read_string, but grows the buffer and appends to to it instead of overwriting.
     pub fn read_string_to_end(&mut self, buf: &mut Vec<u8>, line: bool) -> usize {
         let mut num_chars = 0;
         loop {

--- a/crates/haste_core/src/bitreader.rs
+++ b/crates/haste_core/src/bitreader.rs
@@ -263,6 +263,8 @@ impl<'a> BitReader<'a> {
     //
     // Returns the number of characters left in out when the routine is complete (this will never
     // exceed buf.len()-1).
+    //
+    // Will panic if buff is too small.
     pub fn read_string(&mut self, buf: &mut [u8], line: bool) -> usize {
         assert!(!buf.is_empty());
 
@@ -289,6 +291,20 @@ impl<'a> BitReader<'a> {
         // did it fit?
         assert!(!too_small);
 
+        num_chars
+    }
+
+    // same as read_string, but grows the buffer and appends to to it instead of overwritting.
+    pub fn read_string_to_end(&mut self, buf: &mut Vec<u8>, line: bool) -> usize {
+        let mut num_chars = 0;
+        loop {
+            let val = self.read_byte();
+            if val == 0 || (line && val == b'\n') {
+                break;
+            }
+            buf.push(val);
+            num_chars += 1;
+        }
         num_chars
     }
 


### PR DESCRIPTION
fixes #4

code-comments should explain all the reasoning.

@raimannma utf8 mystery solved. thoughts on the change?

note that i have not updated haste-inspector, can do post-merge, but here's a patch for haste-inspector if you want to try it locally (you'll also have to change haste's git rev in cargo.toml and rebuild wasm).

```diff
diff --git a/crates/haste-wasm/src/lib.rs b/crates/haste-wasm/src/lib.rs
index 657631f..5333262 100644
--- a/crates/haste-wasm/src/lib.rs
+++ b/crates/haste-wasm/src/lib.rs
@@ -121,10 +121,17 @@ impl WrappedParser {
                     .unwrap_throw();
                 let (named_path, var_type) = get_value_info(entity.serializer(), fp);
 
+                let mut value = match field_value {
+                    haste::fieldvalue::FieldValue::String(data) => {
+                        String::from_utf8_lossy(data).into_owned()
+                    }
+                    other => other.to_string(),
+                };
+
                 EntityFieldLi {
                     path: fp.iter().cloned().collect(),
                     named_path,
-                    value: field_value.to_string(),
+                    value,
                     encoded_as: var_type,
                     decoded_as: get_field_value_discriminant_name(field_value).to_string(),
                 }
```

encoding of data in `m_sHeroBuildSerialized` seems similar to https://github.com/SteamDatabase/GameTracking-Deadlock/blob/bd858135dac99651c618bedb14caccd7bbd76541/game/citadel/pak01_dir/cfg/valve_builds.kv3#L67, but not sure.